### PR TITLE
Add CMake build support for Cash-Sloth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.16)
+project(CashSloth LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(cash-sloth
+    src/main.cpp
+    src/cash_sloth_json.cpp
+    src/cash_sloth_style.cpp)
+
+target_include_directories(cash-sloth PRIVATE include)
+
+if (MSVC)
+    target_compile_options(cash-sloth PRIVATE /W4 /permissive- /utf-8)
+    target_compile_definitions(cash-sloth PRIVATE UNICODE _UNICODE)
+else()
+    target_compile_options(cash-sloth PRIVATE -Wall -Wextra -Wpedantic)
+    if (MINGW)
+        target_compile_options(cash-sloth PRIVATE -municode)
+    endif()
+endif()
+
+if (WIN32)
+    target_link_libraries(cash-sloth PRIVATE comctl32 gdi32 uxtheme msimg32)
+    add_custom_command(TARGET cash-sloth POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:cash-sloth>/assets"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/assets" "$<TARGET_FILE_DIR:cash-sloth>/assets")
+endif()
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ mingw32-make CXX=g++
 The resulting binary (`cash-sloth.exe`) is written to the repository root. Run it from
 there so the executable can resolve the JSON assets located in the `assets/` directory.
 
+### Visual Studio / CMake build
+
+If you prefer CMake or Visual Studio, generate a build directory and let CMake copy the
+runtime assets next to the produced executable automatically:
+
+```
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+When the build finishes, the freshly built `cash-sloth.exe` lives under
+`build/Release/` (or the configuration-specific output directory selected by your
+generator) together with an `assets/` folder so you can launch the program immediately.
+
 ## Runtime assets
 
 When distributing the application, place `cash-sloth.exe`, `lauch.exe`, and the `assets`

--- a/include/cash_sloth_json.h
+++ b/include/cash_sloth_json.h
@@ -51,6 +51,7 @@ public:
     JsonValue parse();
 
 private:
+    void skipBom();
     JsonValue parseValue();
     JsonValue parseObject();
     JsonValue parseArray();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,15 @@
-﻿#define NOMINMAX
+#if !defined(_WIN32)
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    std::cerr << "Cash-Sloth POS Touch requires Windows to run." << std::endl;
+    return EXIT_FAILURE;
+}
+
+#else
+
+#define NOMINMAX
 #include <windows.h>
 #include <commctrl.h>
 #include <algorithm>
@@ -1700,3 +1711,5 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR, int nCmd
     return wWinMain(hInstance, hPrevInstance, nullptr, nCmdShow);
 }
 #endif
+
+#endif  // !defined(_WIN32)


### PR DESCRIPTION
## Summary
- add a CMake build configuration that links required Win32 libraries and copies runtime assets beside the executable
- document the new CMake/Visual Studio workflow in the README
- guard the Win32 entry point so non-Windows builds exit with a helpful message

## Testing
- not run (non-Windows environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bdf426588325a30357d399555fb0)