### PR TITLE
Fix NOMINMAX conflicts when compiling on Windows

### DIFF
--- a/include/cash_sloth_style.h
+++ b/include/cash_sloth_style.h
@@ -4,6 +4,10 @@
 #include <optional>
 #include <string>
 #include <vector>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <wingdi.h>
 

--- a/include/cash_sloth_utils.h
+++ b/include/cash_sloth_utils.h
@@ -8,6 +8,10 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 
 namespace cashsloth {

--- a/src/cash_sloth_json.cpp
+++ b/src/cash_sloth_json.cpp
@@ -2,6 +2,10 @@
 
 #include <cctype>
 #include <string>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 
 namespace cashsloth {

--- a/src/cash_sloth_style.cpp
+++ b/src/cash_sloth_style.cpp
@@ -91,7 +91,7 @@ StyleSheet StyleSheet::load(const std::filesystem::path& baseDir) {
             sheet.metrics.productTileHeight = intOr("product_tile_height", sheet.metrics.productTileHeight);
             sheet.metrics.tileGap = intOr("tile_gap", sheet.metrics.tileGap);
             sheet.metrics.quickButtonHeight = intOr("quick_button_height", sheet.metrics.quickButtonHeight);
-            sheet.metrics.quickColumns = std::max(1, intOr("quick_columns", sheet.metrics.quickColumns));
+            sheet.metrics.quickColumns = (std::max)(1, intOr("quick_columns", sheet.metrics.quickColumns));
             sheet.metrics.actionButtonHeight = intOr("action_button_height", sheet.metrics.actionButtonHeight);
             sheet.metrics.panelRadius = intOr("panel_radius", sheet.metrics.panelRadius);
             sheet.metrics.buttonRadius = intOr("button_radius", sheet.metrics.buttonRadius);


### PR DESCRIPTION
## Summary
- define NOMINMAX before including `<windows.h>` in the shared headers and JSON source to stop the OS headers from redefining `min`/`max`
- wrap the remaining use of `std::max` in parentheses so it compiles cleanly even if the macro slips through elsewhere

## Testing
- Not run (Windows-specific build)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e31115448325bb77bdc4036648b5)