### PR TITLE
Improve platform-aware build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,19 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_executable(cash-sloth
+set(CASH_SLOTH_SOURCES
     src/main.cpp
-    src/cash_sloth_json.cpp
-    src/cash_sloth_style.cpp)
+    src/cash_sloth_json.cpp)
+
+if (WIN32)
+    list(APPEND CASH_SLOTH_SOURCES src/cash_sloth_style.cpp)
+endif()
+
+if (WIN32)
+    add_executable(cash-sloth WIN32 ${CASH_SLOTH_SOURCES})
+else()
+    add_executable(cash-sloth ${CASH_SLOTH_SOURCES})
+endif()
 
 target_include_directories(cash-sloth PRIVATE include)
 


### PR DESCRIPTION
## Summary
- build the `cash-sloth` target as a Win32 GUI application only when CMake detects Windows so non-Windows hosts still produce the console stub
- limit Windows-only sources to Windows builds and keep portable sources always included
- replace the `WideCharToMultiByte`-based JSON escape handling with a small UTF-8 encoder so the parser no longer depends on `<windows.h>`

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e922313c8325a72e746165f78f2a)