### PR TITLE
Ensure Win32 GUI target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,18 +13,19 @@ add_executable(cash-sloth WIN32
 
 target_include_directories(cash-sloth PRIVATE include)
 
+if (WIN32)
+    target_compile_definitions(cash-sloth PRIVATE UNICODE _UNICODE)
+    target_link_libraries(cash-sloth PRIVATE comctl32 gdi32 uxtheme msimg32)
+    set_target_properties(cash-sloth PROPERTIES WIN32_EXECUTABLE TRUE)
+endif()
+
 if (MSVC)
     target_compile_options(cash-sloth PRIVATE /W4 /permissive- /utf-8)
-    target_compile_definitions(cash-sloth PRIVATE UNICODE _UNICODE)
 else()
     target_compile_options(cash-sloth PRIVATE -Wall -Wextra -Wpedantic)
     if (MINGW)
         target_compile_options(cash-sloth PRIVATE -municode)
     endif()
-endif()
-
-if (WIN32)
-    target_link_libraries(cash-sloth PRIVATE comctl32 gdi32 uxtheme msimg32)
 endif()
 
 if (MSVC)


### PR DESCRIPTION
## Summary
- set up the cash-sloth executable with the required Win32 GUI properties and Unicode definitions on Windows builds
- retain the existing warning levels for MSVC and non-MSVC toolchains

## Testing
- Not run (Windows-only configuration)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f5fa773c83259674e649f4e711d3)