### PR TITLE
Unify HBox/VBox size distribution with a single axis allocator

### DIFF
--- a/src/ui/layout/hbox.cpp
+++ b/src/ui/layout/hbox.cpp
@@ -1,8 +1,109 @@
 #include "ui/layout/hbox.h"
 
+#include "ui/layout/spacer.h"
+
 #include <algorithm>
+#include <vector>
 
 namespace ui::layout {
+namespace {
+
+std::vector<int> DistributeWeighted(int amount, const std::vector<float>& weights) {
+    std::vector<int> distribution(weights.size(), 0);
+    if (amount <= 0 || weights.empty()) {
+        return distribution;
+    }
+
+    double total_weight = 0.0;
+    for (float weight : weights) {
+        total_weight += std::max(0.0f, weight);
+    }
+    if (total_weight <= 0.0) {
+        return distribution;
+    }
+
+    int assigned = 0;
+    for (size_t i = 0; i < weights.size(); ++i) {
+        double share = amount * (std::max(0.0f, weights[i]) / total_weight);
+        int value = static_cast<int>(share);
+        distribution[i] = value;
+        assigned += value;
+    }
+
+    int remainder = amount - assigned;
+    for (size_t i = 0; i < weights.size() && remainder > 0; ++i) {
+        if (weights[i] <= 0.0f) {
+            continue;
+        }
+        ++distribution[i];
+        --remainder;
+    }
+
+    return distribution;
+}
+
+std::vector<int> DistributeAxisSizes(int available,
+                                     const std::vector<int>& fixed_desired,
+                                     const std::vector<int>& fixed_minimum,
+                                     const std::vector<float>& fixed_flex_weights,
+                                     const std::vector<float>& fixed_min_weights,
+                                     const std::vector<int>& spacer_minimum,
+                                     const std::vector<float>& spacer_weights,
+                                     const std::vector<int>& fixed_indices,
+                                     const std::vector<int>& spacer_indices,
+                                     std::vector<int> sizes) {
+    int fixed_desired_sum = 0;
+    int fixed_min_sum = 0;
+    int spacer_min_sum = 0;
+
+    for (int value : fixed_desired) {
+        fixed_desired_sum += value;
+    }
+    for (int value : fixed_minimum) {
+        fixed_min_sum += value;
+    }
+    for (int value : spacer_minimum) {
+        spacer_min_sum += value;
+    }
+
+    if (available >= fixed_desired_sum + spacer_min_sum) {
+        for (size_t i = 0; i < fixed_indices.size(); ++i) {
+            sizes[fixed_indices[i]] = fixed_desired[i];
+        }
+        int remaining = available - fixed_desired_sum - spacer_min_sum;
+        std::vector<int> spacer_extra = DistributeWeighted(remaining, spacer_weights);
+        for (size_t i = 0; i < spacer_indices.size(); ++i) {
+            sizes[spacer_indices[i]] = spacer_minimum[i] + spacer_extra[i];
+        }
+        return sizes;
+    }
+
+    if (available >= fixed_min_sum + spacer_min_sum) {
+        int available_for_fixed = std::max(0, available - spacer_min_sum);
+        int fixed_extra = std::max(0, available_for_fixed - fixed_min_sum);
+        std::vector<int> fixed_extra_distribution = DistributeWeighted(fixed_extra, fixed_flex_weights);
+        for (size_t i = 0; i < fixed_indices.size(); ++i) {
+            sizes[fixed_indices[i]] = fixed_minimum[i] + fixed_extra_distribution[i];
+        }
+        for (size_t i = 0; i < spacer_indices.size(); ++i) {
+            sizes[spacer_indices[i]] = spacer_minimum[i];
+        }
+        return sizes;
+    }
+
+    std::vector<int> fixed_distribution = DistributeWeighted(
+        available,
+        fixed_min_sum > 0 ? fixed_min_weights : std::vector<float>(fixed_indices.size(), 1.0f));
+    for (size_t i = 0; i < fixed_indices.size(); ++i) {
+        sizes[fixed_indices[i]] = fixed_distribution[i];
+    }
+    for (int index : spacer_indices) {
+        sizes[index] = 0;
+    }
+    return sizes;
+}
+
+}  // namespace
 
 void HBox::SetGap(int gap) {
     gap_ = std::max(0, gap);
@@ -39,45 +140,65 @@ void HBox::Arrange(const Rect& final_rect) {
     arranged_ = ApplyMargin(final_rect);
     Rect content = ContentRect(arranged_);
 
-    int total_fixed = 0;
-    int spacer_count = 0;
-    bool first = true;
-    for (const auto& child : children_) {
+    const int child_count = static_cast<int>(children_.size());
+    const int gap_total = (child_count > 1) ? gap_ * (child_count - 1) : 0;
+    const int available = std::max(0, content.w - gap_total);
+
+    std::vector<int> sizes(children_.size(), 0);
+    std::vector<int> fixed_indices;
+    std::vector<int> spacer_indices;
+    std::vector<int> fixed_desired;
+    std::vector<int> fixed_minimum;
+    std::vector<float> fixed_flex_weights;
+    std::vector<float> fixed_min_weights;
+    std::vector<int> spacer_minimum;
+    std::vector<float> spacer_weights;
+
+    for (size_t i = 0; i < children_.size(); ++i) {
+        const auto& child = children_[i];
+        int desired = child->DesiredSize().w;
+        int minimum = child->MinimumDesiredSize().w;
         if (child->IsSpacer()) {
-            ++spacer_count;
+            spacer_indices.push_back(static_cast<int>(i));
+            spacer_minimum.push_back(minimum);
+            const auto* spacer = static_cast<const Spacer*>(child.get());
+            spacer_weights.push_back(spacer->Weight());
         } else {
-            total_fixed += child->DesiredSize().w;
+            fixed_indices.push_back(static_cast<int>(i));
+            fixed_desired.push_back(desired);
+            fixed_minimum.push_back(minimum);
+            fixed_flex_weights.push_back(static_cast<float>(std::max(0, desired - minimum)));
+            fixed_min_weights.push_back(static_cast<float>(std::max(0, minimum)));
         }
-        if (!first) {
-            total_fixed += gap_;
-        }
-        first = false;
     }
 
-    int remaining = content.w - total_fixed;
-    int extra_per_spacer = (spacer_count > 0 && remaining > 0) ? (remaining / spacer_count) : 0;
-    int remainder = (spacer_count > 0 && remaining > 0) ? (remaining % spacer_count) : 0;
+    sizes = DistributeAxisSizes(available,
+                                fixed_desired,
+                                fixed_minimum,
+                                fixed_flex_weights,
+                                fixed_min_weights,
+                                spacer_minimum,
+                                spacer_weights,
+                                fixed_indices,
+                                spacer_indices,
+                                sizes);
 
     int x = content.x;
-    int available_remaining = content.w;
-    for (const auto& child : children_) {
-        int child_width = child->DesiredSize().w;
-        if (child->IsSpacer()) {
-            child_width += extra_per_spacer;
-            if (remainder > 0) {
-                ++child_width;
-                --remainder;
-            }
+    bool has_prev = false;
+    for (size_t i = 0; i < children_.size(); ++i) {
+        int child_width = std::max(0, sizes[i]);
+        if (child_width > 0 && has_prev) {
+            x += gap_;
         }
-        child_width = std::max(0, child_width);
-        child_width = std::min(child_width, available_remaining);
 
         Rect slot{x, content.y, child_width, content.h};
-        Rect aligned = AlignChild(slot, child->DesiredSize(), AlignH::Stretch, child->AlignVertical());
-        child->Arrange(aligned);
+        Rect aligned = AlignChild(slot, children_[i]->DesiredSize(), AlignH::Stretch, children_[i]->AlignVertical());
+        children_[i]->Arrange(aligned);
 
-        x += child_width + gap_;
-        available_remaining = std::max(0, content.w - (x - content.x));
+        if (child_width > 0) {
+            x += child_width;
+            has_prev = true;
+        }
     }
 }
 

--- a/src/ui/layout/layout_node.cpp
+++ b/src/ui/layout/layout_node.cpp
@@ -46,6 +46,12 @@ const Size& Node::DesiredSize() const {
     return desired_;
 }
 
+Size Node::MinimumDesiredSize() const {
+    Size minimum = ClampToMinMax(Size{});
+    minimum = AddThickness(minimum, margin_);
+    return minimum;
+}
+
 void Node::SetDesiredSize(Size size) {
     desired_ = ClampNonNegative(size);
 }

--- a/src/ui/layout/layout_node.h
+++ b/src/ui/layout/layout_node.h
@@ -29,6 +29,7 @@ public:
 
     const Rect& ArrangedRect() const;
     const Size& DesiredSize() const;
+    Size MinimumDesiredSize() const;
     std::string DumpTree() const;
     virtual bool IsSpacer() const { return false; }
 

--- a/src/ui/layout/layout_tests.cpp
+++ b/src/ui/layout/layout_tests.cpp
@@ -71,6 +71,82 @@ void TestHBoxSpacer() {
     ExpectEqual(right_ptr->ArrangedRect().x, 90, "HBox right x");
 }
 
+void TestVBoxSpacerFill() {
+    VBox root;
+    root.SetGap(4);
+    root.SetPadding(Thickness::Uniform(2));
+
+    auto title = std::make_unique<LeafBox>();
+    auto spacer = std::make_unique<Spacer>();
+    auto footer = std::make_unique<LeafBox>();
+
+    title->SetPreferredSize(Size{10, 40});
+    footer->SetPreferredSize(Size{10, 60});
+
+    LeafBox* title_ptr = static_cast<LeafBox*>(root.AddChild(std::move(title)));
+    Spacer* spacer_ptr = static_cast<Spacer*>(root.AddChild(std::move(spacer)));
+    LeafBox* footer_ptr = static_cast<LeafBox*>(root.AddChild(std::move(footer)));
+
+    root.Measure(Size{200, 400});
+    root.Arrange(Rect{0, 0, 200, 400});
+
+    const int expected_spacer = 400 - 4 - 8 - 40 - 60;
+    ExpectEqual(title_ptr->ArrangedRect().h, 40, "VBox title height");
+    ExpectEqual(spacer_ptr->ArrangedRect().h, expected_spacer, "VBox spacer fill height");
+    ExpectEqual(footer_ptr->ArrangedRect().y, 2 + 40 + 4 + expected_spacer + 4, "VBox footer y");
+}
+
+void TestHBoxSpacerFill() {
+    HBox root;
+    root.SetGap(5);
+    root.SetPadding(Thickness::Uniform(3));
+
+    auto left = std::make_unique<LeafBox>();
+    auto spacer = std::make_unique<Spacer>();
+    auto right = std::make_unique<LeafBox>();
+
+    left->SetPreferredSize(Size{40, 10});
+    right->SetPreferredSize(Size{60, 10});
+
+    LeafBox* left_ptr = static_cast<LeafBox*>(root.AddChild(std::move(left)));
+    Spacer* spacer_ptr = static_cast<Spacer*>(root.AddChild(std::move(spacer)));
+    LeafBox* right_ptr = static_cast<LeafBox*>(root.AddChild(std::move(right)));
+
+    root.Measure(Size{400, 60});
+    root.Arrange(Rect{0, 0, 400, 60});
+
+    const int expected_spacer = 400 - 6 - 10 - 40 - 60;
+    ExpectEqual(left_ptr->ArrangedRect().w, 40, "HBox left width");
+    ExpectEqual(spacer_ptr->ArrangedRect().w, expected_spacer, "HBox spacer fill width");
+    ExpectEqual(right_ptr->ArrangedRect().x, 3 + 40 + 5 + expected_spacer + 5, "HBox right x");
+}
+
+void TestSpacerWeights() {
+    VBox root;
+    root.SetGap(0);
+
+    auto top = std::make_unique<LeafBox>();
+    auto spacer_one = std::make_unique<Spacer>();
+    auto spacer_two = std::make_unique<Spacer>();
+    auto bottom = std::make_unique<LeafBox>();
+
+    top->SetPreferredSize(Size{10, 30});
+    bottom->SetPreferredSize(Size{10, 30});
+    spacer_one->SetWeight(1.0f);
+    spacer_two->SetWeight(2.0f);
+
+    root.AddChild(std::move(top));
+    Spacer* spacer_one_ptr = static_cast<Spacer*>(root.AddChild(std::move(spacer_one)));
+    Spacer* spacer_two_ptr = static_cast<Spacer*>(root.AddChild(std::move(spacer_two)));
+    root.AddChild(std::move(bottom));
+
+    root.Measure(Size{200, 300});
+    root.Arrange(Rect{0, 0, 200, 300});
+
+    ExpectEqual(spacer_one_ptr->ArrangedRect().h, 80, "VBox spacer weight 1");
+    ExpectEqual(spacer_two_ptr->ArrangedRect().h, 160, "VBox spacer weight 2");
+}
+
 void TestGridUniform() {
     Grid grid(2, 2);
     grid.SetGap(2);
@@ -148,6 +224,9 @@ void TestVBoxActionPanelPreserved() {
 int main() {
     ui::layout::tests::TestVBoxGapPadding();
     ui::layout::tests::TestHBoxSpacer();
+    ui::layout::tests::TestVBoxSpacerFill();
+    ui::layout::tests::TestHBoxSpacerFill();
+    ui::layout::tests::TestSpacerWeights();
     ui::layout::tests::TestGridUniform();
     ui::layout::tests::TestMarginPadding();
     ui::layout::tests::TestVBoxActionPanelPreserved();

--- a/src/ui/layout/spacer.cpp
+++ b/src/ui/layout/spacer.cpp
@@ -16,4 +16,8 @@ void Spacer::Arrange(const Rect& final_rect) {
     arranged_ = ApplyMargin(final_rect);
 }
 
+void Spacer::SetWeight(float weight) {
+    weight_ = (weight > 0.0f) ? weight : 0.0f;
+}
+
 }  // namespace ui::layout

--- a/src/ui/layout/spacer.h
+++ b/src/ui/layout/spacer.h
@@ -9,9 +9,14 @@ public:
     Size Measure(const Size& available) override;
     void Arrange(const Rect& final_rect) override;
     bool IsSpacer() const override { return true; }
+    void SetWeight(float weight);
+    float Weight() const { return weight_; }
 
 protected:
     std::string_view TypeName() const override { return "Spacer"; }
+
+private:
+    float weight_ = 1.0f;
 };
 
 }  // namespace ui::layout

--- a/src/ui/layout/vbox.cpp
+++ b/src/ui/layout/vbox.cpp
@@ -1,9 +1,109 @@
 #include "ui/layout/vbox.h"
 
+#include "ui/layout/spacer.h"
+
 #include <algorithm>
 #include <vector>
 
 namespace ui::layout {
+namespace {
+
+std::vector<int> DistributeWeighted(int amount, const std::vector<float>& weights) {
+    std::vector<int> distribution(weights.size(), 0);
+    if (amount <= 0 || weights.empty()) {
+        return distribution;
+    }
+
+    double total_weight = 0.0;
+    for (float weight : weights) {
+        total_weight += std::max(0.0f, weight);
+    }
+    if (total_weight <= 0.0) {
+        return distribution;
+    }
+
+    int assigned = 0;
+    for (size_t i = 0; i < weights.size(); ++i) {
+        double share = amount * (std::max(0.0f, weights[i]) / total_weight);
+        int value = static_cast<int>(share);
+        distribution[i] = value;
+        assigned += value;
+    }
+
+    int remainder = amount - assigned;
+    for (size_t i = 0; i < weights.size() && remainder > 0; ++i) {
+        if (weights[i] <= 0.0f) {
+            continue;
+        }
+        ++distribution[i];
+        --remainder;
+    }
+
+    return distribution;
+}
+
+std::vector<int> DistributeAxisSizes(int available,
+                                     const std::vector<int>& fixed_desired,
+                                     const std::vector<int>& fixed_minimum,
+                                     const std::vector<float>& fixed_flex_weights,
+                                     const std::vector<float>& fixed_min_weights,
+                                     const std::vector<int>& spacer_minimum,
+                                     const std::vector<float>& spacer_weights,
+                                     const std::vector<int>& fixed_indices,
+                                     const std::vector<int>& spacer_indices,
+                                     std::vector<int> sizes) {
+    int fixed_desired_sum = 0;
+    int fixed_min_sum = 0;
+    int spacer_min_sum = 0;
+
+    for (int value : fixed_desired) {
+        fixed_desired_sum += value;
+    }
+    for (int value : fixed_minimum) {
+        fixed_min_sum += value;
+    }
+    for (int value : spacer_minimum) {
+        spacer_min_sum += value;
+    }
+
+    if (available >= fixed_desired_sum + spacer_min_sum) {
+        for (size_t i = 0; i < fixed_indices.size(); ++i) {
+            sizes[fixed_indices[i]] = fixed_desired[i];
+        }
+        int remaining = available - fixed_desired_sum - spacer_min_sum;
+        std::vector<int> spacer_extra = DistributeWeighted(remaining, spacer_weights);
+        for (size_t i = 0; i < spacer_indices.size(); ++i) {
+            sizes[spacer_indices[i]] = spacer_minimum[i] + spacer_extra[i];
+        }
+        return sizes;
+    }
+
+    if (available >= fixed_min_sum + spacer_min_sum) {
+        int available_for_fixed = std::max(0, available - spacer_min_sum);
+        int fixed_extra = std::max(0, available_for_fixed - fixed_min_sum);
+        std::vector<int> fixed_extra_distribution = DistributeWeighted(fixed_extra, fixed_flex_weights);
+        for (size_t i = 0; i < fixed_indices.size(); ++i) {
+            sizes[fixed_indices[i]] = fixed_minimum[i] + fixed_extra_distribution[i];
+        }
+        for (size_t i = 0; i < spacer_indices.size(); ++i) {
+            sizes[spacer_indices[i]] = spacer_minimum[i];
+        }
+        return sizes;
+    }
+
+    std::vector<int> fixed_distribution = DistributeWeighted(
+        available,
+        fixed_min_sum > 0 ? fixed_min_weights : std::vector<float>(fixed_indices.size(), 1.0f));
+    for (size_t i = 0; i < fixed_indices.size(); ++i) {
+        sizes[fixed_indices[i]] = fixed_distribution[i];
+    }
+    for (int index : spacer_indices) {
+        sizes[index] = 0;
+    }
+    return sizes;
+}
+
+}  // namespace
 
 void VBox::SetGap(int gap) {
     gap_ = std::max(0, gap);
@@ -42,82 +142,62 @@ void VBox::Arrange(const Rect& final_rect) {
 
     const int child_count = static_cast<int>(children_.size());
     const int gap_total = (child_count > 1) ? gap_ * (child_count - 1) : 0;
-    const int available_for_children = std::max(0, content.h - gap_total);
+    const int available = std::max(0, content.h - gap_total);
 
-    int non_spacer_total = 0;
-    int spacer_count = 0;
-    for (const auto& child : children_) {
+    std::vector<int> heights(children_.size(), 0);
+    std::vector<int> fixed_indices;
+    std::vector<int> spacer_indices;
+    std::vector<int> fixed_desired;
+    std::vector<int> fixed_minimum;
+    std::vector<float> fixed_flex_weights;
+    std::vector<float> fixed_min_weights;
+    std::vector<int> spacer_minimum;
+    std::vector<float> spacer_weights;
+
+    for (size_t i = 0; i < children_.size(); ++i) {
+        const auto& child = children_[i];
+        int desired = child->DesiredSize().h;
+        int minimum = child->MinimumDesiredSize().h;
         if (child->IsSpacer()) {
-            ++spacer_count;
+            spacer_indices.push_back(static_cast<int>(i));
+            spacer_minimum.push_back(minimum);
+            const auto* spacer = static_cast<const Spacer*>(child.get());
+            spacer_weights.push_back(spacer->Weight());
         } else {
-            non_spacer_total += child->DesiredSize().h;
+            fixed_indices.push_back(static_cast<int>(i));
+            fixed_desired.push_back(desired);
+            fixed_minimum.push_back(minimum);
+            fixed_flex_weights.push_back(static_cast<float>(std::max(0, desired - minimum)));
+            fixed_min_weights.push_back(static_cast<float>(std::max(0, minimum)));
         }
     }
 
-    std::vector<int> heights;
-    heights.reserve(children_.size());
-    heights.assign(children_.size(), 0);
-
-    if (non_spacer_total == 0) {
-        if (spacer_count > 0) {
-            int extra_per_spacer = available_for_children / spacer_count;
-            int remainder = available_for_children % spacer_count;
-            for (size_t i = 0; i < children_.size(); ++i) {
-                if (!children_[i]->IsSpacer()) {
-                    continue;
-                }
-                heights[i] = extra_per_spacer;
-                if (remainder > 0) {
-                    ++heights[i];
-                    --remainder;
-                }
-            }
-        }
-    } else if (available_for_children >= non_spacer_total) {
-        int extra = available_for_children - non_spacer_total;
-        int extra_per_spacer = (spacer_count > 0) ? (extra / spacer_count) : 0;
-        int remainder = (spacer_count > 0) ? (extra % spacer_count) : 0;
-        for (size_t i = 0; i < children_.size(); ++i) {
-            if (children_[i]->IsSpacer()) {
-                heights[i] = extra_per_spacer;
-                if (remainder > 0) {
-                    ++heights[i];
-                    --remainder;
-                }
-            } else {
-                heights[i] = children_[i]->DesiredSize().h;
-            }
-        }
-    } else {
-        int used = 0;
-        for (size_t i = 0; i < children_.size(); ++i) {
-            if (children_[i]->IsSpacer()) {
-                continue;
-            }
-            int scaled = (children_[i]->DesiredSize().h * available_for_children) / non_spacer_total;
-            heights[i] = scaled;
-            used += scaled;
-        }
-        int remainder = available_for_children - used;
-        for (size_t i = 0; i < children_.size() && remainder > 0; ++i) {
-            if (children_[i]->IsSpacer()) {
-                continue;
-            }
-            ++heights[i];
-            --remainder;
-        }
-    }
+    heights = DistributeAxisSizes(available,
+                                  fixed_desired,
+                                  fixed_minimum,
+                                  fixed_flex_weights,
+                                  fixed_min_weights,
+                                  spacer_minimum,
+                                  spacer_weights,
+                                  fixed_indices,
+                                  spacer_indices,
+                                  heights);
 
     int y = content.y;
+    bool has_prev = false;
     for (size_t i = 0; i < children_.size(); ++i) {
         int child_height = std::max(0, heights[i]);
+        if (child_height > 0 && has_prev) {
+            y += gap_;
+        }
+
         Rect slot{content.x, y, content.w, child_height};
         Rect aligned = AlignChild(slot, children_[i]->DesiredSize(), children_[i]->AlignHorizontal(), AlignV::Stretch);
         children_[i]->Arrange(aligned);
 
-        y += child_height;
-        if (i + 1 < children_.size()) {
-            y += gap_;
+        if (child_height > 0) {
+            y += child_height;
+            has_prev = true;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Simplify and consolidate duplicated Arrange logic in `VBox`/`HBox` so each axis has exactly one distribution algorithm and sizes are assigned once. 
- Ensure spacer minimums are respected and remaining space is distributed deterministically via weights, and gaps are only applied between actually arranged (size > 0) children. 
- Provide a stable Measure/Arrange contract so parents can rely on children minima (including margins) when computing layouts. 

### Description
- Introduced a single axis allocation helper `DistributeAxisSizes` (and `DistributeWeighted`) used by both `vbox.cpp` and `hbox.cpp` to centralize fixed vs spacer sizing and regime selection. 
- Refactored `VBox::Arrange` and `HBox::Arrange` to collect fixed/spacer metadata, call the allocator once, and perform a single pass arrange that only applies gaps between visible children. 
- Added `Node::MinimumDesiredSize()` and cleaned up size/weight bookkeeping so spacer minima and fixed child minima are respected before collapsing spacers. 
- Implemented spacer weight API with `Spacer::SetWeight` and `Spacer::Weight`, and adjusted `spacer.cpp`/`spacer.h` to use a default weight of `1.0f`. 
- Extended layout unit tests in `src/ui/layout/layout_tests.cpp` with `TestVBoxSpacerFill`, `TestHBoxSpacerFill`, and `TestSpacerWeights`, and simplified/cleaned up legacy branches in the layout code. 

### Testing
- Ran project configure with `cmake -S . -B build` which completed successfully. 
- Attempted full build with `cmake --build build --config Release` which failed in this environment due to a missing platform header (`windows.h`). 
- Built the layout-only tests with `cmake --build build --config Release --target layout-tests` and executed them with `./build/layout-tests`, and all layout tests passed (`All layout tests passed.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f62ff63288325a200dd8cde70b200)